### PR TITLE
Fixing setVariable and getVariable to replace all . or _'s

### DIFF
--- a/node/lib/vsotask.ts
+++ b/node/lib/vsotask.ts
@@ -51,7 +51,7 @@ export function setResult(result: TaskResult, message) {
 // Input Helpers
 //-----------------------------------------------------
 export function getVariable(name) {
-    var varval = process.env[name.replace('.', '_').toUpperCase()];
+    var varval = process.env[name.replace(/\./g, '_').toUpperCase()];
     debug(name + '=' + varval);
     return varval;
 }
@@ -63,7 +63,7 @@ export function setVariable(name, val) {
     }
 
     var varValue = val || '';
-    process.env[name.replace('.', '_').toUpperCase()] = varValue;
+    process.env[name.replace(/\./g, '_').toUpperCase()] = varValue;
     debug('set ' + name + '=' + varValue);
     command('task.setvariable', {'variable': name || ''}, varValue);
 }

--- a/node/test/tasklib.ts
+++ b/node/test/tasklib.ts
@@ -108,6 +108,24 @@ describe('Test vso-task-lib', function() {
 
 			done();
 		})
+		it('gets a variable', function (done) {
+			this.timeout(1000);
+
+			process.env['BUILD_REPOSITORY_NAME'] = 'Test Repository';
+			var varVal = tl.getVariable('Build.Repository.Name');
+			assert(varVal === 'Test Repository', 'reading a variable should work');
+
+			done();
+		})
+		it('sets a variable', function (done) {
+			this.timeout(1000);
+
+			tl.setVariable('Build.Repository.Uri', 'test value');
+			var varVal = process.env['BUILD_REPOSITORY_URI'];
+			assert(varVal === 'test value', 'setting a variable should work');
+
+			done();
+		})
 		it('sets and gets a variable', function(done) {
 			this.timeout(1000);
 			


### PR DESCRIPTION
variables having multiple dots such as Build.Repository.Uri were not working because of this bug. 