### PR TITLE
Run Title and Publish Test Attachments Changes

### DIFF
--- a/node/lib/vsotask.ts
+++ b/node/lib/vsotask.ts
@@ -408,7 +408,7 @@ export class TestPublisher {
 
     public testRunner: string;
 
-    public publish(resultFiles, mergeResults, platform, config) {
+    public publish(resultFiles, mergeResults, platform, config, runTitle, publishRunAttachments) {
         
         if(mergeResults == 'true') {
             _writeLine("Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.");
@@ -424,8 +424,17 @@ export class TestPublisher {
         if(config) {
             properties['config'] = config;
         }
+		
+		if(runTitle) {
+			properties['runTitle'] = runTitle;
+		}
 
-        for(var i = 0; i < resultFiles.length; i ++) {            
+		if(publishRunAttachments) {
+			properties['publishRunAttachments'] = publishRunAttachments;
+		}			
+
+        for(var i = 0; i < resultFiles.length; i ++) {  
+			properties['fileNumber'] = i.toString();
             command('results.publish',  properties, resultFiles[i]);
         }
     }


### PR DESCRIPTION
Description: The PublishTestResults Task's xplat implementation is currently different from windows implementation. Users choice of Run Title and option to not publish result files do not exist in the current xplat implementation.

Solution: Changes have been made for Junit, xunit and nunit to honor users choice of run ttitle and user can now opt out of publishing test attachments.
https://github.com/Microsoft/vso-agent-tasks/pull/954
https://github.com/Microsoft/vso-agent/pull/168

Testing: Manual for now. Appropriate unit tests will be added if required.